### PR TITLE
Fix bug COM-214, empty batch request

### DIFF
--- a/src/Api/Batch/BatchRequest.php
+++ b/src/Api/Batch/BatchRequest.php
@@ -47,12 +47,15 @@ class BatchRequest
 
     public function execute(): Iterator
     {
-        $this->processedCount = 0;
-        $response = $this->runBatchRequest();
-        do {
-            yield from $this->processBatchResponse($response);
-            $response = $this->getNextPage($response);
-        } while ($response !== null);
+        // Empty batch request cannot be executed, ... if empty => empty iterator is returned
+        if ($this->requests) {
+            $this->processedCount = 0;
+            $response = $this->runBatchRequest();
+            do {
+                yield from $this->processBatchResponse($response);
+                $response = $this->getNextPage($response);
+            } while ($response !== null);
+        }
     }
 
     private function getNextPage(GraphResponse $response): ?GraphResponse

--- a/tests/api/BatchRequestTest.php
+++ b/tests/api/BatchRequestTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\OneDriveWriter\ApiTests;
+
+use PHPUnit\Framework\Assert;
+
+class BatchRequestTest extends BaseTest
+{
+    public function testEmptyBatchRequest(): void
+    {
+        // Test for bug COM-214, when empty batch request resulted to "BadRequest: Invalid batch payload format."
+        $batch = $this->api->createBatchRequest();
+        Assert::assertCount(0, iterator_to_array($batch->execute()));
+    }
+}


### PR DESCRIPTION
Changes:
- same problem as in extractor: https://github.com/keboola/ex-onedrive/pull/2
- preventively fix it here too
- fixed problem with empty BatchRequest, it results to `Invalid batch payload format`