### PR TITLE
Add optional metadata key

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,20 @@ The configuration `config.json` contains following properties in `parameters` ke
     - `driveId` - string: id of [drive resource](https://docs.microsoft.com/en-us/graph/api/resources/drive?view=graph-rest-1.0)    
     - `fileId` - string: id of [driveItem resource](https://docs.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-1.0)
     - `path` - string: format see below 
+    - `metadata` - object (optional): 
+       - Serves to store human-readable data when `driveId` / `fileId` are used to define `workbook`.
+       - The component code is not using content of this metadata. 
+       - UI can use it to store and later show metadata from FilePicker.
 - `worksheet` - object (required): Worksheet, one sheet from workbook's sheets. [Read more](#worksheet).
     - One of `id`, `position` or `name` must be configured.
     - If `id` is set, then `position` cannot be set and vice versa, but `name` can always be present.
     - `id` - string: id of [worksheet resource](https://docs.microsoft.com/en-us/graph/api/resources/worksheet?view=graph-rest-1.0)
     - `name` - string: worksheet name
     - `position` - int: worksheet position, first is 0, hidden sheets are included
+    - `metadata` - object (optional): 
+       - Serves to store human-readable data (eg. sheet name ) when `id` is used to define `worksheet`.
+       - The component code is not using content of this metadata.
+       - UI can use it to store and later show metadata from FilePicker.
 
 ### Workbook
 - Specified by one of [`driveId` and `fileId`] or `path` (not both).

--- a/src/Configuration/Parts/WorkbookDefinition.php
+++ b/src/Configuration/Parts/WorkbookDefinition.php
@@ -25,6 +25,8 @@ class WorkbookDefinition
                 ->scalarNode('fileId')->cannotBeEmpty()->end()
                 // ... OR by search (path, download url, ...)
                 ->scalarNode('path')->cannotBeEmpty()->end()
+                // optional metadata can be always present, it is not used in code
+                ->arrayNode('metadata')->ignoreExtraKeys(true)->end()
             ->end()
             // Not empty
             ->validate()

--- a/src/Configuration/Parts/WorksheetDefinition.php
+++ b/src/Configuration/Parts/WorksheetDefinition.php
@@ -27,6 +27,8 @@ class WorksheetDefinition
                 ->scalarNode('id')->cannotBeEmpty()->end()
                 // ... or position
                 ->scalarNode('position')->cannotBeEmpty()->end()
+                // optional metadata can be always present, it is not used in code
+                ->arrayNode('metadata')->ignoreExtraKeys(true)->end()
             ->end()
             // Only one of id/position allowed
             ->validate()

--- a/tests/phpunit/Config/RunConfigTest.php
+++ b/tests/phpunit/Config/RunConfigTest.php
@@ -148,6 +148,29 @@ class RunConfigTest extends BaseConfigTest
                     ],
                 ],
             ],
+            'valid-plus-metadata' => [
+                [
+                    'authorization' => $this->getValidAuthorization(),
+                    'parameters' => [
+                        'workbook' => [
+                            'driveId' => '1234abc',
+                            'fileId' => '5678def',
+                            'metadata' => [
+                                'a' => 1,
+                                'b' => 'abc',
+                            ],
+                        ],
+                        'worksheet' => [
+                            'name' => 'Sheet 1',
+                            'id' => '9012xyz',
+                            'metadata' => [
+                                'a' => 1,
+                                'b' => 'abc',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 

--- a/tests/phpunit/Config/SyncActionConfigTest.php
+++ b/tests/phpunit/Config/SyncActionConfigTest.php
@@ -55,6 +55,22 @@ class SyncActionConfigTest extends BaseConfigTest
                     ],
                 ],
             ],
+            'valid-ids-plus-metadata' => [
+                [
+                    'action' => 'path',
+                    'authorization' => $this->getValidAuthorization(),
+                    'parameters' => [
+                        'workbook' => [
+                            'driveId' => '...',
+                            'fileId' => '...',
+                            'metadata' => [
+                                'a' => 1,
+                                'b' => 'abc',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
Solving: https://keboola.atlassian.net/browse/COM-244
Slack: https://keboolaglobal.slack.com/archives/C5K31TYKT/p1588604353057200?thread_ts=1587710396.021200&cid=C5K31TYKT

Changes:
 - Added optional `metadata` key for `workbook` and `worksheet`.
 - UI define `workbook` and `worksheet` by their `ID`s, because it is the most stable choice, ... file can be moved and component will be still working.
- ... but it is needed to store human-readable metadata, ... user needs see more info, than just `id`.
 - This metadata is not used in component code.