### PR TITLE
Configurable bulk size, default 10000 rows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ services:
 before_script:
   - export APP_IMAGE=keboola-wr-onedrive
   - docker -v
+  - docker login --username "$DOCKERHUB_USER" --password "$DOCKERHUB_TOKEN"
   - docker build -t $APP_IMAGE .
   - docker run
     -e OAUTH_APP_NAME

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Exports spreadsheets to OneDrive
 The configuration `config.json` contains following properties in `parameters` key: 
 
 - `append` - bool (optional): if sheet exists, rows are appended to the end, default false
+- `bulkSize` - int (optional): number of the rows in one batch / insert API call, default `10 000`
 - `workbook` - object (required): Workbook `XLSX` file. [Read more](#workbook).
    - One of [`driveId` and `fileId`] or `path` must be configured.
     - `driveId` - string: id of [drive resource](https://docs.microsoft.com/en-us/graph/api/resources/drive?view=graph-rest-1.0)    

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Exports spreadsheets to OneDrive
 The configuration `config.json` contains following properties in `parameters` key: 
 
 - `append` - bool (optional): if sheet exists, rows are appended to the end, default false
-- `bulkSize` - int (optional): number of the rows in one batch / insert API call, default `10 000`
+- `batchSize` - int (optional): number of the rows in one batch / insert API call, default `10 000`
 - `workbook` - object (required): Workbook `XLSX` file. [Read more](#workbook).
    - One of [`driveId` and `fileId`] or `path` must be configured.
     - `driveId` - string: id of [drive resource](https://docs.microsoft.com/en-us/graph/api/resources/drive?view=graph-rest-1.0)    

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -63,10 +63,10 @@ class Api
         return $file;
     }
 
-    public function insertRows(Sheet $sheet, bool $append, Iterator $rows, int $bulk = 30000): void
+    public function insertRows(Sheet $sheet, bool $append, Iterator $rows, int $batchSize = 30000): void
     {
         $manager = new InsertRowsManager($this->logger, $this);
-        $manager->insert($sheet, $append, $rows, $bulk);
+        $manager->insert($sheet, $append, $rows, $batchSize);
     }
 
     public function clearSheet(Sheet $sheet): void

--- a/src/Api/InsertRowsManager.php
+++ b/src/Api/InsertRowsManager.php
@@ -22,7 +22,7 @@ class InsertRowsManager
         $this->api = $api;
     }
 
-    public function insert(Sheet $sheet, bool $append, Iterator $rows, int $bulk): void
+    public function insert(Sheet $sheet, bool $append, Iterator $rows, int $batchSize): void
     {
         // Clear
         if (!$append && !$sheet->isNew()) {
@@ -66,7 +66,7 @@ class InsertRowsManager
 
         do {
             // use_keys = false, important!
-            $values = iterator_to_array(new LimitIterator($iterator, 0, $bulk), false);
+            $values = iterator_to_array(new LimitIterator($iterator, 0, $batchSize), false);
             if (empty($values)) {
                 break;
             }

--- a/src/Configuration/Config.php
+++ b/src/Configuration/Config.php
@@ -24,9 +24,9 @@ class Config extends BaseConfig
         return $this->getValue(['parameters', 'append']);
     }
 
-    public function getBulkSize(): int
+    public function getBatchSize(): int
     {
-        return $this->getValue(['parameters', 'bulkSize']);
+        return $this->getValue(['parameters', 'batchSize']);
     }
 
     public function hasDriveId(): bool

--- a/src/Configuration/Config.php
+++ b/src/Configuration/Config.php
@@ -24,6 +24,11 @@ class Config extends BaseConfig
         return $this->getValue(['parameters', 'append']);
     }
 
+    public function getBulkSize(): int
+    {
+        return $this->getValue(['parameters'. 'bulkSize']);
+    }
+
     public function hasDriveId(): bool
     {
         return $this->hasValue(['parameters', 'workbook', 'driveId']);

--- a/src/Configuration/Config.php
+++ b/src/Configuration/Config.php
@@ -26,7 +26,7 @@ class Config extends BaseConfig
 
     public function getBulkSize(): int
     {
-        return $this->getValue(['parameters'. 'bulkSize']);
+        return $this->getValue(['parameters', 'bulkSize']);
     }
 
     public function hasDriveId(): bool

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -7,7 +7,6 @@ namespace Keboola\OneDriveWriter\Configuration;
 use Keboola\Component\Config\BaseConfigDefinition;
 use Keboola\OneDriveWriter\Configuration\Parts\WorkbookDefinition;
 use Keboola\OneDriveWriter\Configuration\Parts\WorksheetDefinition;
-use Keboola\OneDriveWriter\Exception\InvalidConfigException;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
@@ -23,6 +22,7 @@ class ConfigDefinition extends BaseConfigDefinition
         $parametersNode
             ->children()
                 ->booleanNode('append')->defaultValue(false)->end()
+                ->integerNode('bulkSize')->defaultValue(10000)->end()
                 // Workbook is one XLSX file
                 ->append(WorkbookDefinition::getDefinition())
                 // In one workbook are multiple worksheets, specify one

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -22,7 +22,7 @@ class ConfigDefinition extends BaseConfigDefinition
         $parametersNode
             ->children()
                 ->booleanNode('append')->defaultValue(false)->end()
-                ->integerNode('bulkSize')->defaultValue(10000)->end()
+                ->integerNode('batchSize')->defaultValue(10000)->end()
                 // Workbook is one XLSX file
                 ->append(WorkbookDefinition::getDefinition())
                 // In one workbook are multiple worksheets, specify one

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -57,7 +57,7 @@ class Writer
         }
 
         // Insert rows
-        $this->api->insertRows($sheet, $this->config->getAppend(), $csv);
+        $this->api->insertRows($sheet, $this->config->getAppend(), $csv, $this->config->getBulkSize());
     }
 
     private function findCsv(): SplFileInfo

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -57,7 +57,7 @@ class Writer
         }
 
         // Insert rows
-        $this->api->insertRows($sheet, $this->config->getAppend(), $csv, $this->config->getBulkSize());
+        $this->api->insertRows($sheet, $this->config->getAppend(), $csv, $this->config->getBatchSize());
     }
 
     private function findCsv(): SplFileInfo

--- a/tests/phpunit/Config/RunConfigTest.php
+++ b/tests/phpunit/Config/RunConfigTest.php
@@ -16,7 +16,7 @@ class RunConfigTest extends BaseConfigTest
     public function testValidConfig(array $config): void
     {
         new Config($config, new ConfigDefinition());
-        $this->addToAssertionCount(1); // Assert no error
+        $this->expectNotToPerformAssertions();
     }
 
     /**
@@ -167,6 +167,21 @@ class RunConfigTest extends BaseConfigTest
                                 'a' => 1,
                                 'b' => 'abc',
                             ],
+                        ],
+                    ],
+                ],
+            ],
+            'valid-bulk-size' => [
+                [
+                    'authorization' => $this->getValidAuthorization(),
+                    'parameters' => [
+                        'bulkSize' => 12345,
+                        'workbook' => [
+                            'path' => '/path/to/file',
+                        ],
+                        'worksheet' => [
+                            'name' => 'Sheet 1',
+                            'position' => 0,
                         ],
                     ],
                 ],

--- a/tests/phpunit/Config/RunConfigTest.php
+++ b/tests/phpunit/Config/RunConfigTest.php
@@ -171,11 +171,11 @@ class RunConfigTest extends BaseConfigTest
                     ],
                 ],
             ],
-            'valid-bulk-size' => [
+            'valid-batch-size' => [
                 [
                     'authorization' => $this->getValidAuthorization(),
                     'parameters' => [
-                        'bulkSize' => 12345,
+                        'batchSize' => 12345,
                         'workbook' => [
                             'path' => '/path/to/file',
                         ],


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/COM-714

Changes:
- Bulk size is configurable in `config.json`.
- Default value `30 000` -> `10 000` (maximum request size is 4MB).