### PR TITLE
add sessionId to all main api calls

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -6,6 +6,7 @@ namespace Keboola\OneDriveWriter\Api;
 
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
+use Keboola\OneDriveWriter\Api\Model\WorkbookSession;
 use Keboola\OneDriveWriter\Exception\GatewayTimeoutException;
 use Keboola\OneDriveWriter\Exception\UserException;
 use Throwable;
@@ -49,10 +50,27 @@ class Api
 
     private ?ClientInterface $httpClient = null;
 
+    private ?WorkbookSession $workbookSession = null;
+
     public function __construct(Graph $graphApi, LoggerInterface $logger)
     {
         $this->graphApi = $graphApi;
         $this->logger = $logger;
+    }
+
+    public function __destruct()
+    {
+        $this->closeSession();
+    }
+
+    public function hasSessionId(): bool
+    {
+        return $this->workbookSession !== null;
+    }
+
+    public function getSessionId(): ?string
+    {
+        return $this->workbookSession ? $this->workbookSession->getSessionId() : null;
     }
 
     public function getAccountName(): string
@@ -65,6 +83,7 @@ class Api
     {
         $uploader = new FileUploader($this);
         $file = $uploader->upload($endpoint, __DIR__ . '/Fixtures/empty.xlsx');
+        $this->createWorkbookSessionId($file->getDriveId(), $file->getFileId());
         $this->logger->info(sprintf('New workbook "%s" created.', implode('/', $file->getPathname())));
         return $file;
     }
@@ -73,21 +92,20 @@ class Api
         Sheet $sheet,
         bool $append,
         Iterator $rows,
-        int $batchSize = 30000,
-        ?string $sessionId = null
+        int $batchSize = 30000
     ): void {
         $manager = new InsertRowsManager($this->logger, $this);
-        $manager->insert($sheet, $append, $rows, $batchSize, $sessionId);
+        $manager->insert($sheet, $append, $rows, $batchSize);
     }
 
-    public function clearSheet(Sheet $sheet, ?string $sessionId = null): void
+    public function clearSheet(Sheet $sheet): void
     {
         $endpoint = '/drives/{driveId}/items/{fileId}/workbook/worksheets/{worksheetId}';
         $uri = $endpoint . '/range/clear';
 
         $headers = [];
-        if ($sessionId) {
-            $headers['Workbook-Session-Id'] = $sessionId;
+        if ($this->workbookSession instanceof WorkbookSession) {
+            $headers['Workbook-Session-Id'] = $this->workbookSession->getSessionId();
         }
 
         $this->post(
@@ -115,14 +133,13 @@ class Api
         string $driveId,
         string $fileId,
         string $worksheetId,
-        string $newName,
-        ?string $sessionId = null
+        string $newName
     ): void {
         $uri = '/drives/{driveId}/items/{fileId}/workbook/worksheets/{worksheetId}';
 
         $headers = [];
-        if ($sessionId) {
-            $headers['Workbook-Session-Id'] = $sessionId;
+        if ($this->workbookSession instanceof WorkbookSession) {
+            $headers['Workbook-Session-Id'] = $this->workbookSession->getSessionId();
         }
 
         $this->patch(
@@ -135,7 +152,7 @@ class Api
         $this->logger->info(sprintf('Sheet renamed to "%s".', $newName));
     }
 
-    public function getSheetHeader(Sheet $sheet, ?string $sessionId = null): TableHeader
+    public function getSheetHeader(Sheet $sheet): TableHeader
     {
         // Table header is first row in worksheet
         // Table can be shifted because we use "usedRange".
@@ -143,8 +160,8 @@ class Api
         $uri = $endpoint . '/usedRange(valuesOnly=true)/row(row=0)?$select=address,text';
 
         $headers = [];
-        if ($sessionId) {
-            $headers['Workbook-Session-Id'] = $sessionId;
+        if ($this->workbookSession instanceof WorkbookSession) {
+            $headers['Workbook-Session-Id'] = $this->workbookSession->getSessionId();
         }
 
         $body = $this
@@ -168,14 +185,14 @@ class Api
         return $header;
     }
 
-    public function getSheetRange(Sheet $sheet, ?string $sessionId = null): TableRange
+    public function getSheetRange(Sheet $sheet): TableRange
     {
         $endpoint = '/drives/{driveId}/items/{fileId}/workbook/worksheets/{worksheetId}';
         $uri = $endpoint . '/usedRange(valuesOnly=true)?$select=address';
 
         $headers = [];
-        if ($sessionId) {
-            $headers['Workbook-Session-Id'] = $sessionId;
+        if ($this->workbookSession instanceof WorkbookSession) {
+            $headers['Workbook-Session-Id'] = $this->workbookSession->getSessionId();
         }
 
         $body = $this
@@ -204,8 +221,12 @@ class Api
     public function getSheetName(string $driveId, string $fileId, string $worksheetId): string
     {
         $uri = '/drives/{driveId}/items/{fileId}/workbook/worksheets/{worksheetId}?$select=name';
+        $headers = [];
+        if ($this->workbookSession instanceof WorkbookSession) {
+            $headers['Workbook-Session-Id'] = $this->workbookSession->getSessionId();
+        }
         $body = $this
-            ->get($uri, ['driveId' => $driveId, 'fileId' => $fileId, 'worksheetId' => $worksheetId])
+            ->get($uri, ['driveId' => $driveId, 'fileId' => $fileId, 'worksheetId' => $worksheetId], $headers)
             ->getBody();
         return $body['name'];
     }
@@ -251,7 +272,11 @@ class Api
 
         // Load list of worksheets in workbook
         $uri = '/drives/{driveId}/items/{fileId}/workbook/worksheets?$select=id,name,position';
-        $body = $this->get($uri, ['driveId' => $driveId, 'fileId' => $fileId])->getBody();
+        $headers = [];
+        if ($this->workbookSession instanceof WorkbookSession) {
+            $headers['Workbook-Session-Id'] = $this->workbookSession->getSessionId();
+        }
+        $body = $this->get($uri, ['driveId' => $driveId, 'fileId' => $fileId], $headers)->getBody();
 
         // Search by position
         $worksheet = null;
@@ -282,8 +307,13 @@ class Api
     {
         // Load list of worksheets in workbook
         $uri = '/drives/{driveId}/items/{fileId}/workbook/worksheets?$select=id,position,name,visibility';
+        $headers = [];
+        if ($this->workbookSession instanceof WorkbookSession) {
+            $headers['Workbook-Session-Id'] = $this->workbookSession->getSessionId();
+        }
+
         $body = $this
-            ->get($uri, ['driveId' => $driveId, 'fileId' => $fileId])
+            ->get($uri, ['driveId' => $driveId, 'fileId' => $fileId], $headers)
             ->getBody();
 
         // Map to object and load header in batch request
@@ -321,26 +351,33 @@ class Api
         }
     }
 
-    public function getWorkbookSessionId(string $driveId, string $fileId): ?string
+    public function createWorkbookSessionId(string $driveId, string $fileId): void
     {
         $uri = '/drives/{driveId}/items/{fileId}/workbook/createSession';
-        $response = $this->post(
-            $uri,
-            [
-                'driveId' => $driveId,
-                'fileId' => $fileId,
-            ],
-            [
-                'persistChanges' => true,
-            ],
-            [
-                'Prefer' => 'respond-async',
-            ],
-        );
+
+        try {
+            $response = $this->post(
+                $uri,
+                [
+                    'driveId' => $driveId,
+                    'fileId' => $fileId,
+                ],
+                [
+                    'persistChanges' => true,
+                ],
+                [
+                    'Prefer' => 'respond-async',
+                ],
+            );
+        } catch (ResourceNotFoundException $e) {
+            throw new ResourceNotFoundException('Configured workbook XLSX file not found.', 0, $e);
+        }
 
         switch ($response->getStatus()) {
             case 201:
-                return $response->getBody()['id'];
+                $this->workbookSession = new WorkbookSession($driveId, $fileId, $response->getBody()['id']);
+                $this->logger->info('Write data using the session.');
+                return;
             case 202:
                 $responseHeader = $response->getHeaders();
 
@@ -355,38 +392,47 @@ class Api
 
                 if ($status !== 'succeeded') {
                     $this->logger->info('The workbook session could not be created.');
-                    return null;
+                    return;
                 }
 
                 $sessionResource = $this->get($session['resourceLocation'])->getBody();
 
-                return $sessionResource['id'];
+                $this->workbookSession = new WorkbookSession($driveId, $fileId, $sessionResource['id']);
+                $this->logger->info('Write data using the session.');
+                return;
             default:
                 $this->logger->info('The workbook session could not be created.');
-                return null;
         }
     }
 
-    public function closeSession(string $driveId, string $fileId, string $sessionId): void
+    public function closeSession(): void
     {
+        if (!$this->workbookSession) {
+            return;
+        }
+
         $uri = '/drives/{driveId}/items/{fileId}/workbook/closeSession';
-        $this->post(
-            $uri,
-            [
-                'driveId' => $driveId,
-                'fileId' => $fileId,
-            ],
-            [],
-            [
-                'Workbook-Session-Id' => $sessionId,
-            ],
-        );
+        try {
+            $this->post(
+                $uri,
+                [
+                    'driveId' => $this->workbookSession->getDriveId(),
+                    'fileId' => $this->workbookSession->getFileId(),
+                ],
+                [],
+                [
+                    'Workbook-Session-Id' => $this->workbookSession->getSessionId(),
+                ],
+            );
+        } catch (Throwable $e) {
+        }
     }
 
     public function searchWorkbook(string $search = ''): File
     {
         $finder = new WorkbooksFinder($this, $this->logger);
         $file = $finder->search($search);
+        $this->createWorkbookSessionId($file->getDriveId(), $file->getFileId());
         $this->logger->info(sprintf('Found workbook "%s".', $file->getName()));
         return $file;
     }

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -124,7 +124,16 @@ class Api
     public function createSheet(string $driveId, string $fileId, string $newName): string
     {
         $uri = '/drives/{driveId}/items/{fileId}/workbook/worksheets';
-        $body = $this->post($uri, ['driveId' => $driveId, 'fileId' => $fileId], [ 'name' => $newName])->getBody();
+        $headers = [];
+        if ($this->workbookSession instanceof WorkbookSession) {
+            $headers['Workbook-Session-Id'] = $this->workbookSession->getSessionId();
+        }
+        $body = $this->post(
+            $uri,
+            ['driveId' => $driveId, 'fileId' => $fileId],
+            [ 'name' => $newName],
+            $headers
+        )->getBody();
         $this->logger->info(sprintf('New sheet "%s" created.', $newName));
         return $body['id'];
     }

--- a/src/Api/InsertRowsManager.php
+++ b/src/Api/InsertRowsManager.php
@@ -23,18 +23,18 @@ class InsertRowsManager
         $this->api = $api;
     }
 
-    public function insert(Sheet $sheet, bool $append, Iterator $rows, int $batchSize, ?string $sessionId = null): void
+    public function insert(Sheet $sheet, bool $append, Iterator $rows, int $batchSize): void
     {
         // Clear
         if (!$append && !$sheet->isNew()) {
-            $this->api->clearSheet($sheet, $sessionId);
+            $this->api->clearSheet($sheet);
         }
 
         // Determine offset
         $range = !$sheet->isNew() && $append ?
-            $this->api->getSheetRange($sheet, $sessionId) : null;
+            $this->api->getSheetRange($sheet) : null;
         $orgHeader = $range && !$range->isEmpty() ?
-            $this->api->getSheetHeader($sheet, $sessionId) : null;
+            $this->api->getSheetHeader($sheet) : null;
 
         if ($range && !$range->isEmpty()) {
             $startCol = Helpers::columnStrToInt($range->getStartColumn());
@@ -80,8 +80,8 @@ class InsertRowsManager
             $uri = $endpoint . '/range(address=\'{startCol}{startRow}:{endCol}{endRow}\')';
 
             $headers = [];
-            if ($sessionId) {
-                $headers['Workbook-Session-Id'] = $sessionId;
+            if ($this->api->hasSessionId()) {
+                $headers['Workbook-Session-Id'] = $this->api->getSessionId();
             }
 
             $this->api->patch(

--- a/src/Api/Model/WorkbookSession.php
+++ b/src/Api/Model/WorkbookSession.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\OneDriveWriter\Api\Model;
+
+class WorkbookSession
+{
+    private string $driveId;
+
+    private string $fileId;
+
+    private string $sessionId;
+
+    public function __construct(string $driveId, string $fileId, string $sessionId)
+    {
+        $this->driveId = $driveId;
+        $this->fileId = $fileId;
+        $this->sessionId = $sessionId;
+    }
+
+    public function getDriveId(): string
+    {
+        return $this->driveId;
+    }
+
+    public function getFileId(): string
+    {
+        return $this->fileId;
+    }
+
+    public function getSessionId(): string
+    {
+        return $this->sessionId;
+    }
+}

--- a/src/SheetProvider.php
+++ b/src/SheetProvider.php
@@ -65,6 +65,7 @@ class SheetProvider
 
         // Get by IDS
         if ($config->hasDriveId() && $config->hasFileId()) {
+            $this->api->createWorkbookSessionId($config->getDriveId(), $config->getFileId());
             return $this->getFileByIds($config->getDriveId(), $config->getFileId());
         }
 

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -46,33 +46,18 @@ class Writer
             return;
         }
 
-        $sessionId = $this->api->getWorkbookSessionId(
-            $sheet->getDriveId(),
-            $sheet->getFileId(),
-        );
-
-        if ($sessionId) {
-            $this->logger->info('Write data using the session.');
-        }
-
         // Rename sheet
         if ($this->config->hasWorksheetName() && $this->config->getWorksheetName() !== $sheet->getName()) {
             $this->api->renameSheet(
                 $sheet->getDriveId(),
                 $sheet->getFileId(),
                 $sheet->getId(),
-                $this->config->getWorksheetName(),
-                $sessionId
+                $this->config->getWorksheetName()
             );
         }
 
         // Insert rows
-        $this->api->insertRows($sheet, $this->config->getAppend(), $csv, $this->config->getBatchSize(), $sessionId);
-
-        // Close session if exists
-        if ($sessionId) {
-            $this->api->closeSession($sheet->getDriveId(), $sheet->getFileId(), $sessionId);
-        }
+        $this->api->insertRows($sheet, $this->config->getAppend(), $csv, $this->config->getBatchSize());
     }
 
     private function findCsv(): SplFileInfo

--- a/tests/datadir/escape-expression/expected-stdout
+++ b/tests/datadir/escape-expression/expected-stdout
@@ -1,4 +1,4 @@
-Found input CSV file "input-file.csv".
 Write data using the session.
+Found input CSV file "input-file.csv".
 Sheet cleared.
 Inserted 3 rows.

--- a/tests/datadir/write-append-empty-file/expected-stdout
+++ b/tests/datadir/write-append-empty-file/expected-stdout
@@ -1,7 +1,7 @@
 Searching for "%a.xlsx" in drive "%a".
+Write data using the session.
 Found workbook "%a.xlsx".
 Found worksheet "Sheet1" at position "0".
 Found input CSV file "input-file.csv".
-Write data using the session.
 Sheet is empty.
 Inserted 3 rows.

--- a/tests/datadir/write-append-hidden-sheet/expected-stdout
+++ b/tests/datadir/write-append-hidden-sheet/expected-stdout
@@ -1,8 +1,8 @@
 Searching for "%a.xlsx" in drive "%a".
+Write data using the session.
 Found workbook "%a.xlsx".
 Found worksheet "Hidden Sheet 3" at position "2".
 Found input CSV file "input-file.csv".
-Write data using the session.
 Current sheet range: "A48:C50"
 Current sheet header "A48:C48": "Col_4", "Col_5", "Col_6"
 Inserted 2 rows.

--- a/tests/datadir/write-append-one-sheet-file/expected-stdout
+++ b/tests/datadir/write-append-one-sheet-file/expected-stdout
@@ -1,8 +1,8 @@
 Searching for "%a.xlsx" in drive "%a".
+Write data using the session.
 Found workbook "%a.xlsx".
 Found worksheet "Only One Sheet" at position "0".
 Found input CSV file "input-file.csv".
-Write data using the session.
 Current sheet range: "A1:C3"
 Current sheet header "A1:C1": "Col_1", "Col_2", "Col_3"
 Inserted 2 rows.

--- a/tests/datadir/write-empty-csv-file/expected-stdout
+++ b/tests/datadir/write-empty-csv-file/expected-stdout
@@ -1,4 +1,5 @@
 Searching for "%a.xlsx" in drive "%a".
+Write data using the session.
 Found workbook "%a.xlsx".
 Found worksheet "Sheet1" at position "0".
 Found input CSV file "input-file.csv".

--- a/tests/datadir/write-file-path-drive-me/expected-stdout
+++ b/tests/datadir/write-file-path-drive-me/expected-stdout
@@ -1,7 +1,7 @@
 Searching for "%a.xlsx" in personal OneDrive.
+Write data using the session.
 Found workbook "%a.xlsx".
 Found worksheet "Only One Sheet" at position "0".
 Found input CSV file "input-file.csv".
-Write data using the session.
 Sheet cleared.
 Inserted 3 rows.

--- a/tests/datadir/write-file-path-drive-site/expected-stdout
+++ b/tests/datadir/write-file-path-drive-site/expected-stdout
@@ -1,7 +1,7 @@
 Searching for "%a.xlsx" in site "%a".
+Write data using the session.
 Found workbook "%a.xlsx".
 Found worksheet "Only One Sheet" at position "0".
 Found input CSV file "input-file.csv".
-Write data using the session.
 Sheet cleared.
 Inserted 3 rows.

--- a/tests/datadir/write-file-path-drive/expected-stdout
+++ b/tests/datadir/write-file-path-drive/expected-stdout
@@ -1,7 +1,7 @@
 Searching for "%a.xlsx" in drive "%a".
+Write data using the session.
 Found workbook "%a.xlsx".
 Found worksheet "Only One Sheet" at position "0".
 Found input CSV file "input-file.csv".
-Write data using the session.
 Sheet cleared.
 Inserted 3 rows.

--- a/tests/datadir/write-file-path-not-found-created-append/expected-stdout
+++ b/tests/datadir/write-file-path-not-found-created-append/expected-stdout
@@ -1,8 +1,8 @@
 Searching for "%a" in personal OneDrive.
+Write data using the session.
 New workbook "%a" created.
 Found worksheet "New" at position "0".
 Found input CSV file "input-file.csv".
-Write data using the session.
 Sheet renamed to "Sheet Test Name".
 Sheet cleared.
 Inserted 3 rows.

--- a/tests/datadir/write-file-path-not-found-created-overwrite/expected-stdout
+++ b/tests/datadir/write-file-path-not-found-created-overwrite/expected-stdout
@@ -1,8 +1,8 @@
 Searching for "%a" in personal OneDrive.
+Write data using the session.
 New workbook "%a" created.
 Found worksheet "New" at position "0".
 Found input CSV file "input-file.csv".
-Write data using the session.
 Sheet renamed to "Sheet Test Name".
 Sheet is empty.
 Inserted 3 rows.

--- a/tests/datadir/write-multiple-csv-files/expected-stderr
+++ b/tests/datadir/write-multiple-csv-files/expected-stderr
@@ -1,1 +1,1 @@
-Expected one CSV file, found multiple: "file2.csv", "file1.csv".
+Expected one CSV file, found multiple: "file%d.csv", "file%d.csv".

--- a/tests/datadir/write-overwrite-empty-file/expected-stdout
+++ b/tests/datadir/write-overwrite-empty-file/expected-stdout
@@ -1,7 +1,7 @@
 Searching for "%a.xlsx" in drive "%a".
+Write data using the session.
 Found workbook "%a.xlsx".
 Found worksheet "Sheet1" at position "0".
 Found input CSV file "input-file.csv".
-Write data using the session.
 Sheet cleared.
 Inserted 3 rows.

--- a/tests/datadir/write-overwrite-hidden-sheet/expected-stdout
+++ b/tests/datadir/write-overwrite-hidden-sheet/expected-stdout
@@ -1,7 +1,7 @@
 Searching for "%a.xlsx" in drive "%a".
+Write data using the session.
 Found workbook "%a.xlsx".
 Found worksheet "Hidden Sheet 3" at position "2".
 Found input CSV file "input-file.csv".
-Write data using the session.
 Sheet cleared.
 Inserted 3 rows.

--- a/tests/datadir/write-overwrite-one-sheet-file/expected-stdout
+++ b/tests/datadir/write-overwrite-one-sheet-file/expected-stdout
@@ -1,7 +1,7 @@
 Searching for "%a.xlsx" in drive "%a".
+Write data using the session.
 Found workbook "%a.xlsx".
 Found worksheet "Only One Sheet" at position "0".
 Found input CSV file "input-file.csv".
-Write data using the session.
 Sheet cleared.
 Inserted 3 rows.

--- a/tests/datadir/write-rename-sheet/expected-stdout
+++ b/tests/datadir/write-rename-sheet/expected-stdout
@@ -1,8 +1,8 @@
 Searching for "%a.xlsx" in personal OneDrive.
+Write data using the session.
 Found workbook "%a.xlsx".
 Found worksheet "Only One Sheet" at position "0".
 Found input CSV file "input-file.csv".
-Write data using the session.
 Sheet renamed to "New Sheet Name".
 Sheet cleared.
 Inserted 3 rows.

--- a/tests/datadir/write-same-sheet-name/expected-stdout
+++ b/tests/datadir/write-same-sheet-name/expected-stdout
@@ -1,7 +1,7 @@
 Searching for "%a.xlsx" in personal OneDrive.
+Write data using the session.
 Found workbook "%a.xlsx".
 Found worksheet "Only One Sheet" at position "0".
 Found input CSV file "input-file.csv".
-Write data using the session.
 Sheet cleared.
 Inserted 3 rows.

--- a/tests/datadir/write-sheet-by-id/expected-stdout
+++ b/tests/datadir/write-sheet-by-id/expected-stdout
@@ -1,4 +1,4 @@
-Found input CSV file "input-file.csv".
 Write data using the session.
+Found input CSV file "input-file.csv".
 Sheet cleared.
 Inserted 3 rows.

--- a/tests/datadir/write-sheet-by-name-found/expected-stdout
+++ b/tests/datadir/write-sheet-by-name-found/expected-stdout
@@ -1,7 +1,7 @@
 Searching for "%a.xlsx" in personal OneDrive.
+Write data using the session.
 Found workbook "%a.xlsx".
 Found worksheet "Only One Sheet" at position "0".
 Found input CSV file "input-file.csv".
-Write data using the session.
 Sheet cleared.
 Inserted 3 rows.

--- a/tests/datadir/write-sheet-by-name-not-found-created-append/expected-stdout
+++ b/tests/datadir/write-sheet-by-name-not-found-created-append/expected-stdout
@@ -1,6 +1,6 @@
 Searching for "%a.xlsx" in personal OneDrive.
+Write data using the session.
 Found workbook "%a.xlsx".
 New sheet "Not Found Sheet" created.
 Found input CSV file "input-file.csv".
-Write data using the session.
 Inserted 3 rows.

--- a/tests/datadir/write-sheet-by-name-not-found-created-overwrite/expected-stdout
+++ b/tests/datadir/write-sheet-by-name-not-found-created-overwrite/expected-stdout
@@ -1,6 +1,6 @@
 Searching for "%a.xlsx" in personal OneDrive.
+Write data using the session.
 Found workbook "%a.xlsx".
 New sheet "Not Found Sheet" created.
 Found input CSV file "input-file.csv".
-Write data using the session.
 Inserted 3 rows.


### PR DESCRIPTION
Trochu jsem to musel předělat... teď se sessionId ukládá:
 - když máme driveId a fileId z configu tak se získá rovnou
 - nebo při zakládání workbooku
to jsou jediný dva případy kdy se může vytvořit a uložím je do proměnné v api a potom jí automaticky přidávám k api callům

mělo by to být lepší i v tom že se bude přidávat u sync akcí (což je v správně)