### PR TITLE
Show error message from API when refreshing of token fails

### DIFF
--- a/src/Auth/TokenDataManager.php
+++ b/src/Auth/TokenDataManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\OneDriveWriter\Auth;
 
 use ArrayObject;
+use Generator;
 use Keboola\Component\JsonHelper;
 use Keboola\OneDriveWriter\Exception\AccessTokenInitException;
 use League\OAuth2\Client\Token\AccessToken;
@@ -32,7 +33,7 @@ class TokenDataManager
         }
     }
 
-    public function load(): iterable
+    public function load(): Generator
     {
         // Load tokens from state.json
         $authDataJson = $this->state[self::STATE_AUTH_DATA_KEY] ?? null;

--- a/src/Auth/TokenProviderFactory.php
+++ b/src/Auth/TokenProviderFactory.php
@@ -14,10 +14,13 @@ class TokenProviderFactory
 
     private ArrayObject $stateObject;
 
-    public function __construct(Config $config, ArrayObject $stateObject)
+    private LoggerInterface $logger;
+
+    public function __construct(Config $config, ArrayObject $stateObject, LoggerInterface $logger)
     {
         $this->config = $config;
         $this->stateObject = $stateObject;
+        $this->logger = $logger;
     }
 
     public function create(): TokenProvider
@@ -27,7 +30,8 @@ class TokenProviderFactory
         return new RefreshTokenProvider(
             $this->config->getOAuthApiAppKey(),
             $this->config->getOAuthApiAppSecret(),
-            $tokenDataManager
+            $tokenDataManager,
+            $this->logger
         );
     }
 }

--- a/src/Component.php
+++ b/src/Component.php
@@ -38,7 +38,7 @@ class Component extends BaseComponent
         $config = $this->getConfig();
         $this->stateObject = new ArrayObject($this->getInputState());
 
-        $tokenProviderFactory = new TokenProviderFactory($config, $this->stateObject);
+        $tokenProviderFactory = new TokenProviderFactory($config, $this->stateObject, $logger);
         $tokenProvider = $tokenProviderFactory->create();
         $apiFactory = new ApiFactory($logger, $tokenProvider);
         $this->api = $apiFactory->create();

--- a/tests/api/AuthTest.php
+++ b/tests/api/AuthTest.php
@@ -100,7 +100,8 @@ class AuthTest extends BaseTest
 
         $this->expectException(AccessTokenRefreshException::class);
         $this->expectExceptionMessage(
-            'Microsoft OAuth API token refresh failed, please reset authorization in the extractor configuration.'
+            'Microsoft OAuth API token refresh failed (invalid_grant). ' .
+            'Please reset authorization in the extractor configuration.'
         );
         $tokenProvider->get();
     }
@@ -155,7 +156,8 @@ class AuthTest extends BaseTest
 
         $this->expectException(AccessTokenRefreshException::class);
         $this->expectExceptionMessage(
-            'Microsoft OAuth API token refresh failed, please reset authorization in the extractor configuration.'
+            'Microsoft OAuth API token refresh failed (invalid_grant). ' .
+            'Please reset authorization in the extractor configuration.'
         );
         $tokenProvider->get();
     }
@@ -184,24 +186,24 @@ class AuthTest extends BaseTest
     {
         return [
             'invalid-app-id' => [
-                'Microsoft OAuth API token refresh failed, ' .
-                'please reset authorization in the extractor configuration.',
+                'Microsoft OAuth API token refresh failed (invalid_grant). ' .
+                'Please reset authorization in the extractor configuration.',
                 'invalid-app-id',
                 getenv('OAUTH_APP_SECRET'),
                 getenv('OAUTH_ACCESS_TOKEN'),
                 getenv('OAUTH_REFRESH_TOKEN'),
             ],
             'invalid-app-secret' => [
-                'Microsoft OAuth API token refresh failed, ' .
-                'please reset authorization in the extractor configuration.',
+                'Microsoft OAuth API token refresh failed (invalid_client). ' .
+                'Please reset authorization in the extractor configuration.',
                 getenv('OAUTH_APP_ID'),
                 'invalid-app-secret',
                 getenv('OAUTH_ACCESS_TOKEN'),
                 getenv('OAUTH_REFRESH_TOKEN'),
             ],
             'invalid-refresh-token' => [
-                'Microsoft OAuth API token refresh failed, ' .
-                'please reset authorization in the extractor configuration.',
+                'Microsoft OAuth API token refresh failed (invalid_grant). ' .
+                'Please reset authorization in the extractor configuration.',
                 getenv('OAUTH_APP_ID'),
                 getenv('OAUTH_APP_SECRET'),
                 getenv('OAUTH_ACCESS_TOKEN'),

--- a/tests/api/BaseTest.php
+++ b/tests/api/BaseTest.php
@@ -60,7 +60,7 @@ abstract class BaseTest extends TestCase
         $config->method('getOAuthApiData')->willReturn($oauthData);
 
         $state = new ArrayObject();
-        $tokenProviderFactory = new TokenProviderFactory($config, $state);
+        $tokenProviderFactory = new TokenProviderFactory($config, $state, $this->logger);
         $tokenProvider = $tokenProviderFactory->create();
         $apiFactory = new ApiFactory($this->logger, $tokenProvider);
         return $apiFactory->create();
@@ -85,7 +85,7 @@ abstract class BaseTest extends TestCase
                 'refresh_token' => $refreshToken,
             ];
         $dataManager = new TokenDataManager($oauthData, $state);
-        return new RefreshTokenProvider($appId, $appSecret, $dataManager);
+        return new RefreshTokenProvider($appId, $appSecret, $dataManager, $this->logger);
     }
 
     protected function checkEnvironment(array $vars): void

--- a/tests/fixtures/FixturesApi.php
+++ b/tests/fixtures/FixturesApi.php
@@ -13,6 +13,7 @@ use Keboola\OneDriveWriter\Api\Helpers;
 use Keboola\OneDriveWriter\Auth\RefreshTokenProvider;
 use Keboola\OneDriveWriter\Auth\TokenDataManager;
 use Keboola\OneDriveWriter\Exception\BatchRequestException;
+use Psr\Log\NullLogger;
 use Retry\BackOff\ExponentialBackOffPolicy;
 use Retry\Policy\CallableRetryPolicy;
 use Retry\RetryProxy;
@@ -123,7 +124,7 @@ class FixturesApi
             'refresh_token' => $refreshToken,
         ];
         $dataManager = new TokenDataManager($oauthData, new ArrayObject());
-        $tokenProvider = new RefreshTokenProvider($appId, $appSecret, $dataManager);
+        $tokenProvider = new RefreshTokenProvider($appId, $appSecret, $dataManager, new NullLogger());
         $apiFactory = new GraphApiFactory();
         return $apiFactory->create($tokenProvider->get());
     }


### PR DESCRIPTION
SLACK: https://keboolaglobal.slack.com/archives/C0556UCG4RK/p1696922414278079

Udělal bych normální release, není to nic proti ničemu :) 