### PR TITLE
Set authority URL from stack parameters if present

### DIFF
--- a/src/Auth/RefreshTokenProvider.php
+++ b/src/Auth/RefreshTokenProvider.php
@@ -26,14 +26,18 @@ class RefreshTokenProvider implements TokenProvider
 
     private LoggerInterface $logger;
 
+    private string $authorityUrl;
+
     public function __construct(
         string $appId,
         string $appSecret,
+        ?string $authorityUrl,
         TokenDataManager $dataManager,
         LoggerInterface $logger
     ) {
         $this->appId = $appId;
         $this->appSecret = $appSecret;
+        $this->authorityUrl = $authorityUrl ?? self::AUTHORITY_URL;
         $this->dataManager = $dataManager;
         $this->logger = $logger;
     }
@@ -96,8 +100,8 @@ class RefreshTokenProvider implements TokenProvider
         return new GenericProvider([
             'clientId' => $appId,
             'clientSecret' => $appSecret,
-            'urlAuthorize' => self::AUTHORITY_URL . self::AUTHORIZE_ENDPOINT,
-            'urlAccessToken' => self::AUTHORITY_URL . self::TOKEN_ENDPOINT,
+            'urlAuthorize' => $this->authorityUrl . self::AUTHORIZE_ENDPOINT,
+            'urlAccessToken' => $this->authorityUrl . self::TOKEN_ENDPOINT,
             'urlResourceOwnerDetails' => '',
             'scopes' => implode(' ', self::SCOPES),
         ]);

--- a/src/Auth/TokenProviderFactory.php
+++ b/src/Auth/TokenProviderFactory.php
@@ -30,6 +30,7 @@ class TokenProviderFactory
         return new RefreshTokenProvider(
             $this->config->getOAuthApiAppKey(),
             $this->config->getOAuthApiAppSecret(),
+            $this->config->getImageParameters()['oneDriveAuthorityUrl'] ?? null,
             $tokenDataManager,
             $this->logger
         );

--- a/tests/api/BaseTest.php
+++ b/tests/api/BaseTest.php
@@ -85,7 +85,7 @@ abstract class BaseTest extends TestCase
                 'refresh_token' => $refreshToken,
             ];
         $dataManager = new TokenDataManager($oauthData, $state);
-        return new RefreshTokenProvider($appId, $appSecret, $dataManager, $this->logger);
+        return new RefreshTokenProvider($appId, $appSecret, null, $dataManager, $this->logger);
     }
 
     protected function checkEnvironment(array $vars): void

--- a/tests/fixtures/FixturesApi.php
+++ b/tests/fixtures/FixturesApi.php
@@ -124,7 +124,7 @@ class FixturesApi
             'refresh_token' => $refreshToken,
         ];
         $dataManager = new TokenDataManager($oauthData, new ArrayObject());
-        $tokenProvider = new RefreshTokenProvider($appId, $appSecret, $dataManager, new NullLogger());
+        $tokenProvider = new RefreshTokenProvider($appId, $appSecret, null, $dataManager, new NullLogger());
         $apiFactory = new GraphApiFactory();
         return $apiFactory->create($tokenProvider->get());
     }

--- a/tests/phpunit/ErrorResponseHandlingTest.php
+++ b/tests/phpunit/ErrorResponseHandlingTest.php
@@ -93,7 +93,7 @@ class ErrorResponseHandlingTest extends TestCase
             'refresh_token' => $refreshToken,
         ];
         $dataManager = new TokenDataManager($oauthData, new ArrayObject());
-        $tokenProvider = new RefreshTokenProvider($appId, $appSecret, $dataManager, $logger);
+        $tokenProvider = new RefreshTokenProvider($appId, $appSecret, null, $dataManager, $logger);
         $apiFactory = new GraphApiFactory();
         return $apiFactory->create($tokenProvider->get());
     }


### PR DESCRIPTION
SLACK: https://keboolaglobal.slack.com/archives/C0556UCG4RK/p1698830765676959?thread_ts=1696922414.278079&cid=C0556UCG4RK

U single-tenat app konfigurace v Azure (a tak to má spořka nakonfigurovaný) je potřeba použít specificky EP pro ten tenant místo `common` EP.

@ondrajodas Doufám, že to takhle funguje, že ty component's stack parameters se mergují do image parameters? Aspoň tak jsem to pochopil z docky...