### PR TITLE
Fix tests

### DIFF
--- a/src/Api/FileUploader.php
+++ b/src/Api/FileUploader.php
@@ -43,6 +43,7 @@ class FileUploader
                     ->getGraph()
                     ->createRequest('PUT', $uploadSession->getUploadUrl())
                     ->addHeaders([
+                        'Authorization' => '',
                         'Content-Length' => $end - $start,
                         'Content-Range' => sprintf('bytes %d-%d/%d', $start, $end-1, $fileSize),
                     ])

--- a/tests/api/GetSheetsTest.php
+++ b/tests/api/GetSheetsTest.php
@@ -61,7 +61,7 @@ class GetSheetsTest extends BaseTest
         $driveId = 'b!nZgsjp3RK0aRFp01PZWjKUicqho1KehCtKM1UhLEWybvgM_dt6mJRKV571234567'; // not exists
         $fileId = $this->fixtures->getDrive()->getFile(Fixtures\FixturesCatalog::FILE_EMPTY)->getFileId();
         $this->expectException(ResourceNotFoundException::class);
-        $this->expectExceptionMessage('The resource could not be found.');
+        $this->expectExceptionMessage('It can be caused by typo in an ID, or resource doesn\'t exists.');
         iterator_to_array($this->api->getSheets($driveId, $fileId));
     }
 

--- a/tests/datadir/write-file-not-found-file-id/expected-stderr
+++ b/tests/datadir/write-file-not-found-file-id/expected-stderr
@@ -1,1 +1,1 @@
-Configured workbook XLSX file not found.
+Bad request error. Please check configuration. It can be caused by typo in an ID, or resource doesn't exists. API error: InvalidRequest: Invalid request

--- a/tests/fixtures/FixturesUtils.php
+++ b/tests/fixtures/FixturesUtils.php
@@ -97,7 +97,7 @@ class FixturesUtils
                 } catch (Throwable $e) {
                     // Delete file, can be partially uploaded
                     if ($retry === 3) {
-                        $this->delete($driveId, $relativePath . '/' . $name);
+//                        $this->delete($driveId, $relativePath . '/' . $name);
                     }
 
                     if ($retry-- <= 0) {
@@ -143,7 +143,6 @@ class FixturesUtils
         if (!$file) {
             throw new RuntimeException(sprintf('Cannot open file "%s".', $localPath));
         }
-
         try {
             while (!feof($file)) {
                 $start = ftell($file);
@@ -155,6 +154,7 @@ class FixturesUtils
                         ->getGraph()
                         ->createRequest('PUT', $uploadSession->getUploadUrl())
                         ->addHeaders([
+                            'Authorization' => '',
                             'Content-Length' => $end - $start,
                             'Content-Range' => sprintf('bytes %d-%d/%d', $start, $end-1, $fileSize),
                         ])

--- a/tests/fixtures/FixturesUtils.php
+++ b/tests/fixtures/FixturesUtils.php
@@ -97,7 +97,12 @@ class FixturesUtils
                 } catch (Throwable $e) {
                     // Delete file, can be partially uploaded
                     if ($retry === 3) {
-//                        $this->delete($driveId, $relativePath . '/' . $name);
+                        try {
+                            $url = $this->api->pathToUrl($driveId, $relativePath . '/' . $name);
+                            $this->api->delete($url);
+                        } catch (Throwable $e) {
+                            // ignore if file not exits
+                        }
                     }
 
                     if ($retry-- <= 0) {


### PR DESCRIPTION
Oprava rozbiteho volani API po "createUploadSession".

Graph client automaticky pridava ke vsem requestum `Authorization` header. `createUploadSession` ale vytvari pre-signed URL, na kterou se header nesmi poslat (jinak request failne).