### PR TITLE
fix(SUPPORT-14649): add retry logic for InvalidSession errors

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -8,6 +8,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use Keboola\OneDriveWriter\Api\Model\WorkbookSession;
 use Keboola\OneDriveWriter\Exception\GatewayTimeoutException;
+use Keboola\OneDriveWriter\Exception\InvalidSessionException;
 use Keboola\OneDriveWriter\Exception\UserException;
 use Throwable;
 use Iterator;
@@ -444,6 +445,12 @@ class Api
         $retryPolicy = new CallableRetryPolicy(function (Throwable $e) {
             // Retry on connect exception, eg. Could not resolve host: login.microsoftonline.com
             if ($e instanceof ConnectException) {
+                return true;
+            }
+
+            if ($e instanceof InvalidSessionException) {
+                $this->workbookSession = null;
+                $this->logger->info('Session expired, will recreate and retry.');
                 return true;
             }
 

--- a/src/Api/Helpers.php
+++ b/src/Api/Helpers.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use Keboola\OneDriveWriter\Exception\BadRequestException;
 use Keboola\OneDriveWriter\Exception\BatchRequestException;
 use Keboola\OneDriveWriter\Exception\GatewayTimeoutException;
+use Keboola\OneDriveWriter\Exception\InvalidSessionException;
 use Keboola\OneDriveWriter\Exception\UserException;
 use Normalizer;
 use GuzzleHttp\Exception\RequestException;
@@ -98,6 +99,14 @@ class Helpers
         } elseif ($error && strpos($error, 'BadRequest: ') === 0) {
             // eg. BadRequest: Tenant does not have a SPO license.
             return new BadRequestException($error, 0, $e);
+        } elseif ($error && strpos($error, 'InvalidSession:') === 0) {
+            return new InvalidSessionException(
+                'OneDrive API session expired or is invalid. ' .
+                'The session will be recreated automatically. ' .
+                'API error: ' . $error,
+                $e->getCode(),
+                $e
+            );
         } elseif ($e->getCode() === 400) {
             // BadRequest, eg. bad fileId, "-1, Microsoft.SharePoint.Client.InvalidClientQueryException"
             return new BadRequestException(sprintf(

--- a/src/Exception/InvalidSessionException.php
+++ b/src/Exception/InvalidSessionException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\OneDriveWriter\Exception;
+
+use Keboola\CommonExceptions\UserExceptionInterface;
+
+class InvalidSessionException extends \Exception implements UserExceptionInterface
+{
+
+}

--- a/tests/datadir/DatadirTest.php
+++ b/tests/datadir/DatadirTest.php
@@ -174,9 +174,11 @@ class DatadirTest extends AbstractDatadirTestCase
         }
         if ($specification->getExpectedStdout() !== null) {
             // Match format, not exact same
+            // Filter out InvalidSession retry messages (transient API errors that are automatically retried)
+            $actualOutput = $this->filterInvalidSessionRetryMessages($runProcess->getOutput());
             $this->assertStringMatchesFormat(
                 trim($specification->getExpectedStdout()),
-                trim($runProcess->getOutput()),
+                trim($actualOutput),
                 'Failed asserting stdout output'
             );
         }
@@ -209,5 +211,21 @@ class DatadirTest extends AbstractDatadirTestCase
         }
 
         return $localPath;
+    }
+
+    private function filterInvalidSessionRetryMessages(string $output): string
+    {
+        $lines = explode("\n", $output);
+        $filteredLines = array_filter($lines, function (string $line): bool {
+            // Filter out InvalidSession retry messages
+            if (strpos($line, 'Session expired, will recreate and retry.') !== false) {
+                return false;
+            }
+            if (strpos($line, 'InvalidSession:') !== false && strpos($line, 'Retrying...') !== false) {
+                return false;
+            }
+            return true;
+        });
+        return implode("\n", $filteredLines);
     }
 }


### PR DESCRIPTION
## Summary

Adds retry logic for Microsoft Graph API `InvalidSession` errors that started occurring around December 10, 2025. Microsoft's API now more aggressively times out workbook sessions due to inactivity, returning `invalidSessionReCreatable` errors.

**Changes:**
- New `InvalidSessionException` class to identify session expiration errors
- Detection of `InvalidSession:` errors in `Helpers::processRequestException` with improved error message
- Retry logic in `Api::executeWithRetry` that clears the expired session and retries the request
- Test update to filter out InvalidSession retry messages from stdout comparison (these are transient and non-deterministic)

## Updates since last revision

CI now passes. Added `filterInvalidSessionRetryMessages()` method to `DatadirTest.php` to handle test failures caused by transient retry messages appearing in stdout. The retry logic was confirmed working in CI - real InvalidSession errors were caught, logged, and retried successfully during test runs.

## Review & Testing Checklist for Human

- [ ] **CRITICAL: Verify session recreation logic** - The retry clears `$this->workbookSession = null` but doesn't explicitly recreate it. Verify that requests work correctly without a session, or that the session gets recreated somewhere in the retry flow. Microsoft docs say to "recreate a session and resume work" - current implementation just clears and retries.
- [ ] **Test with actual InvalidSession error** - Run the component against a configuration that triggers the InvalidSession error to verify the retry works end-to-end
- [ ] **Verify test filter isn't too broad** - The new `filterInvalidSessionRetryMessages()` filters lines containing "Session expired, will recreate and retry." or "InvalidSession:" + "Retrying..." - confirm this doesn't accidentally hide other important output

**Recommended test plan:**
1. Deploy to a test environment and run against a configuration that previously failed with InvalidSession
2. Verify in logs that "Session expired, will recreate and retry." message appears and the job succeeds

### Notes

- Microsoft documentation confirms `invalidSessionReCreatable` is a transient error that should be handled by recreating the session: https://learn.microsoft.com/en-us/graph/workbook-error-handling
- Investigation found zero InvalidSession errors before Dec 10, 2025 - suggests Microsoft changed their API behavior
- This affects both `wr-onedrive` and `ex-onedrive` components (same codebase pattern)
- CI confirmed the retry logic works: real InvalidSession errors were caught, logged, and retried successfully during test runs

**Link to Devin run:** https://app.devin.ai/sessions/e5db42911bc0447d900b4947d83c6d5e
**Requested by:** zdenek.srotyr@keboola.com (@ZdenekSrotyr)